### PR TITLE
Add stored procedure transpiler wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,25 @@ user_id price
 
 See also: [Writing a Python SQL engine from scratch](https://github.com/tobymao/sqlglot/blob/main/posts/python_sql_engine.md).
 
+### Stored Procedure Transpilation with LLM
+
+SQLGlot includes helpers to handle stored procedures using a local LLM such as [Ollama](https://ollama.ai/). The LLM extracts transpilable SQL from the procedure and the resulting queries are wrapped in SingleStore syntax.
+
+```python
+from sqlglot import transpile_procedure
+
+proc = """
+CREATE PROCEDURE p AS
+BEGIN
+  SELECT * FROM foo;
+END
+"""
+
+print(transpile_procedure(proc))
+```
+
+The wrapper sends prompts to `http://localhost:11434/api/generate` by default and returns a `DELIMITER`-wrapped procedure ready for execution in SingleStore.
+
 ## Used By
 
 * [SQLMesh](https://github.com/TobikoData/sqlmesh)

--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -48,7 +48,15 @@ from sqlglot.expressions import (
 from sqlglot.generator import Generator as Generator
 from sqlglot.parser import Parser as Parser
 from sqlglot.schema import MappingSchema as MappingSchema, Schema as Schema
-from sqlglot.tokens import Token as Token, Tokenizer as Tokenizer, TokenType as TokenType
+from sqlglot.tokens import (
+    Token as Token,
+    Tokenizer as Tokenizer,
+    TokenType as TokenType,
+)
+from sqlglot.procedure import (
+    extract_transpilable_sql as extract_transpilable_sql,
+    transpile_procedure as transpile_procedure,
+)
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
@@ -69,7 +77,9 @@ pretty = False
 """Whether to format generated SQL by default."""
 
 
-def tokenize(sql: str, read: DialectType = None, dialect: DialectType = None) -> t.List[Token]:
+def tokenize(
+    sql: str, read: DialectType = None, dialect: DialectType = None
+) -> t.List[Token]:
     """
     Tokenizes the given SQL string.
 

--- a/sqlglot/procedure.py
+++ b/sqlglot/procedure.py
@@ -1,0 +1,50 @@
+"""Helpers for transpiling stored procedures via a local LLM."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+import requests
+
+
+LLM_URL = "http://localhost:11434/api/generate"
+"""Default endpoint for a local LLM (Ollama compatible)."""
+
+
+def _call_llm(prompt: str, model: str = "llama2", url: str = LLM_URL) -> str:
+    """Call a local LLM to process a prompt and return the raw response."""
+    payload = {"model": model, "prompt": prompt, "stream": False}
+    response = requests.post(url, json=payload, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("response", "")
+
+
+def extract_transpilable_sql(
+    procedure: str, model: str = "llama2", url: str = LLM_URL
+) -> List[str]:
+    """Use a local LLM to extract transpilable SQL statements from a stored procedure."""
+    prompt = (
+        "Extract the SQL statements from the following stored procedure. "
+        "Return the statements separated by a semicolon.\n" + procedure
+    )
+    raw = _call_llm(prompt, model=model, url=url)
+    return [s.strip() for s in raw.split(";") if s.strip()]
+
+
+def transpile_procedure(
+    procedure: str,
+    read: str = "tsql",
+    write: str = "singlestore",
+    model: str = "llama2",
+    url: str = LLM_URL,
+) -> str:
+    """Transpile SQL inside a stored procedure into SingleStore syntax."""
+    from sqlglot import transpile
+
+    statements = extract_transpilable_sql(procedure, model=model, url=url)
+    converted: Iterable[str] = (
+        transpile(stmt, read=read, write=write)[0] for stmt in statements
+    )
+    body = ";\n".join(converted) + ";"
+    return f"DELIMITER //\n{body}\n//\nDELIMITER ;"


### PR DESCRIPTION
## Summary
- add `procedure.py` to handle stored procedure transpilation with a local LLM
- expose `transpile_procedure` and `extract_transpilable_sql` in package init
- document usage of the new wrapper in the README

## Testing
- `ruff check sqlglot/procedure.py`
- `ruff check sqlglot/__init__.py`
- `make unit` *(fails: ConnectionRefusedError for singlestoredb and missing numpy/pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68497f5d06b8832eac092185b4258a4a